### PR TITLE
Refactor Convert From CSV Command To Take in kwargs

### DIFF
--- a/commands/convert_from.py
+++ b/commands/convert_from.py
@@ -175,7 +175,7 @@ def parse_kwargs(ctx):
         else:
             raise click.UsageError(f"Saw ill-formed option {arg}.")
 
-        for values in rhs.split(","):
+        for values in rhs.split(";"):
             k, sep, v = values.partition(":")
             argslist.append((opt, (k, v) if v else k))
 
@@ -199,14 +199,20 @@ def parse_kwargs(ctx):
 
 def cast_kwargs(v, checkbool=True):
     bool = {"True": True, "False": False}
-    if v.isnumeric():
+    if "," in v and not isstring(v):
+        v = [cast_kwargs(val, checkbool=checkbool) for val in v.split(",")]
+    elif v.isnumeric():
         v = int(v)
     elif checkbool and v in bool:
         v = bool[v]
-    elif v[0] == '"' and v[-1] == '"':
+    elif isstring(v):
         v = v[1:-1]
 
     return v
+
+
+def isstring(v):
+    return v[0] == '"' and v[-1] == '"'
 
 
 convert_from.add_command(csv)

--- a/commands/convert_from.py
+++ b/commands/convert_from.py
@@ -11,13 +11,22 @@ def convert_from():
 
 
 class FilterList(click.ParamType):
+    """
+    Support passing in TileDB's FilterList types to tiledb.from_csv().
+
+    The input syntax is identical to how all other kwargs arguments are parsed.
+    However, additional parsing and conversion is done here to ensure that the
+    given Filters are valid, the window or compression value is passed to the
+    Filter as necessary, and the resulting argument is casted to a FilterList type.
+    """
+
     name = "filter_list"
 
     def convert(self, value, param, ctx):
         raw_filters = str(value).split(";")
 
         if len(raw_filters) == 1:
-            return self.parse_filter_list(value, param, ctx)
+            return self._parse_filter_list(value, param, ctx)
         else:
             filters = dict()
             for f in raw_filters:
@@ -27,10 +36,10 @@ class FilterList(click.ParamType):
                         param,
                         ctx,
                     )
-                filters.update(self.parse_filter_list(f, param, ctx))
+                filters.update(self._parse_filter_list(f, param, ctx))
             return filters
 
-    def parse_filter_list(self, value, param, ctx):
+    def _parse_filter_list(self, value, param, ctx):
         values = str(value).split(":")
         if len(values) == 1:
             return self._parse_single_attr(values[0], param, ctx)
@@ -111,9 +120,10 @@ class FilterList(click.ParamType):
     metavar="<filter[=opt]>,... | <attr>:<filter[=opt]>;...",
     help=(
         "Provide a comma separated list of filters to apply to each attribute "
-        "(e.g. --attr-filters filter1,filter2=5,filter=3). Map an attribute with "
+        "(e.g. --attr-filters LZ4Filter=10,BitShuffleFilter). Map an attribute with "
         "a given list of filters with a colon separated by a semicolon "
-        "(e.g. --attr-filters attr1:filter1,filter2=4;attr2:filter1=0. Some filters "
+        "(e.g. --attr-filters attr1:LZ4Filter=10,BitShuffleFilter;"
+        "attr2:DoubleDeltaFilter,PositiveDeltaFilter=3. Some filters "
         "take in a compression level or window size that can be assigned using the "
         "= operator as shown in the examples above."
     ),
@@ -123,9 +133,10 @@ class FilterList(click.ParamType):
     "--coords-filters",
     metavar="<filter[=opt]>,,...",
     help=(
-        "Provide a comma separated list of filters to apply to each coordinate. "
-        "Some filters take in a compression level or window size that can be assigned "
-        "using the = operator."
+        "Provide a comma separated list of filters to apply to each coordinate "
+        "(e.g. --coords-filters LZ4Filter=10,BitShuffleFilter). "
+        "Some filters take in a compression level or window size that can be "
+        "assigned using the = operator as shown in the example above."
     ),
     type=FilterList(),
 )
@@ -134,9 +145,10 @@ class FilterList(click.ParamType):
     metavar="<filter[=opt]>,... | <dim>:<filter[=opt]>;...",
     help=(
         "Provide a comma separated list of filters to apply to each dimension "
-        "(e.g. --dim-filters filter1,filter2=5,filter=3). Map a dimension with "
+        "(e.g. --dim-filters LZ4Filter=10,BitShuffleFilter). Map a dimension with "
         "a given list of filters with a colon separated by a semicolon "
-        "(e.g. --dim-filters dim1:filter1,filter2=4;dim2:filter1=0. Some filters "
+        "(e.g. --dim-filters dim1:LZ4Filter=10,BitShuffleFilter;"
+        "dim2:DoubleDeltaFilter,PositiveDeltaFilter=3. Some filters "
         "take in a compression level or window size that can be assigned using the "
         "= operator as shown in the examples above."
     ),
@@ -146,8 +158,117 @@ class FilterList(click.ParamType):
 def csv(ctx, csv_file, uri, attr_filters, coords_filters, dim_filters):
     """
     Convert a csv_file into a TileDB array located at uri.
+
+    How To Pass Keyword Options
+    ---------------------------
+
+    Any keyword supported by TileDB's from_csv() or Panda's
+    read_csv() functions that are not listed under the "Options" section of
+    this help documentation below can be passed to this CLI command using the
+    method described below.
+
+    A keyword uses two dashes at the beginning and contains an argument that is
+    separated by a single space. Any underscores in the keyword may be replaced
+    with dashes. For example, passing the flags --allows-duplicates True and
+    --allows_duplicates True are both valid calls to pass
+    tiledb.from_csv(allows_duplicates=True).
+
+    For primitive argument types, int types are any valid Python <int> and <bool>
+    types are True or False. All other types will be considered <str>.
+
+    --int 2
+    --bool True
+    --str helloworld
+
+    To force <str> type, enclose the argument in double quotes.
+
+    --int-is-str "2"
+    --bool_is_str "False"
+
+    Pass in lists using comma separated values.
+
+    --list-abc a,b,c
+    --list_123 1,2,3
+    --list-bool True,True,False
+    --list_mix False,"1",2
+
+    Pass in dictionaries where each entry is separated by semicolons. Each entry
+    is a key and value pairing separated by a colon.
+
+    --dict-int hello:1
+    --dict-strs hello:world;"1":"2"
+    --dict-bools good:True;bye:False
+    --dict_mix bool:False;str:"1";int:2;3:"three";list:hey,"hi",True,1
+
+    An actual example using
+
+        tiledb convert-from csv s3://tiledb-unittest/inputs/increment_sparse1.csv example_array_convert_from_csv.tdb --sparse True --mode ingest --timestamp 1
+
+        tiledb dump array example_array_convert_from_csv.tdb --timestamp 1
+        > {'a': array([21, 31, 41, 51, 61]),
+        > 'b': array([22, 32, 42, 52, 62]),
+        > 'c': array([23, 33, 43, 53, 63]),
+        > 'x': array([2, 3, 4, 5, 6])}
+
+    For more examples and usage of the kwargs syntax, please see view
+    the TestCSV() unit tests located in tests/test_convert_from.py.
+
+
+    (An Attempt at) Backus-Naur Form
+    ---------------------------------
+
+    "kwargs" are made up of one or more "kwarg" options. Multiple "kwarg" options
+    are separated by a single space.
+
+        kwargs ::= kwarg | kwarg kwargs
+
+    A "kwarg" is made up of a "kw" and arg. The "kw" contains two dashes in front
+    and is separated by the "arg" using a single space.
+
+        kwarg ::= --kw arg
+
+    "kw" is most* keywords supported by TileDB's from_csv() or Panda's
+    read_csv() functions. Dashes may be used in lieu of underscores, but both
+    are valid. For example, --allows-duplicates and --allows_duplicates both
+    correctly refer to the same keyword argument.
+
+    "kw" currently does NOT include attr_filters, coords_filters, and dim_filters.
+    These require special parsing that cannot be generally handled using
+    this function and are handled through Click though they still generally use the
+    same syntax as described below. More keywords may need special parsing in the
+    future.
+
+    "arg" may be of type "argval", "list", or "dict".
+
+        arg ::= argval | list | dict
+
+    "argval" is of Python type <int>, <bool>, or <str>.
+
+        argval ::= <int> | <bool> | <str>
+
+    "list" is at least two "argval" symbols separated by a comma without
+    any spaces.
+
+        list ::= argval,argval | argval,list
+
+    "dict" contains one or more "dictentry" symbols. Multiple "dictentry"
+    symbols are separated by a semicolon with no spaces.
+
+        dict ::=  dictentry | dictentry;dict
+
+    "dictentry" is made up of a "dictkey" and "dictval" separated by a colon.
+
+        dictentry ::= dictkey:dictval
+
+    "dictkey" is an "argval" that is a Python hashtable type.
+
+        dictkey ::= <str> | <int>
+
+    "dictval" is an "argval" or "list".
+
+        dictval ::= argval | list
     """
-    kwargs = parse_kwargs(ctx)
+    kwargs = parse_kwargs(ctx.args)
 
     # there are options that require special parsing that cannot be generally
     # handled using the parse_kwargs() function above.
@@ -163,10 +284,17 @@ def csv(ctx, csv_file, uri, attr_filters, coords_filters, dim_filters):
     tiledb.from_csv(uri, csv_file, **kwargs)
 
 
-def parse_kwargs(ctx):
+def parse_kwargs(args):
+    """
+    Parse the given raw string of args into the kwargs dictionary. Details of the
+    syntax can be found under the documentation for csv().
+
+    :param args: A string containing all kwargs options and values to be parsed.
+    :return: A dictionary containing the given kwargs options and values.
+    """
     argslist = []
 
-    argsiter = iter(ctx.args)
+    argsiter = iter(args)
     for arg in argsiter:
         lhs, rhs = arg, next(argsiter)
 
@@ -182,7 +310,7 @@ def parse_kwargs(ctx):
     kwargs = collections.defaultdict(list)
     for k, v in argslist:
         v = (
-            (cast_kwargs(v[0], checkbool=False), cast_kwargs(v[1]))
+            (cast_kwargs(v[0], castbool=False), cast_kwargs(v[1]))
             if isinstance(v, tuple)
             else cast_kwargs(v)
         )
@@ -197,22 +325,49 @@ def parse_kwargs(ctx):
     return kwargs
 
 
-def cast_kwargs(v, checkbool=True):
+def cast_kwargs(token, castbool=True):
+    """
+    Cast the token to the appropriate type. Tokens may be of type list, int,
+    Boolean, or string.
+
+    Tokens that begin and end with double quotes are strings. Given that the
+    token is not a string, tokens containing commas will be separated out into a
+    list of tokens. Numberic tokens will be casted to ints and True and False
+    are casted to Boolean values. Note that "123" and "False" are examples of
+    strings because they are enclosed in double quotes. ""Hello"" is a string
+    that represents the string \"Hello\" in quotes. Even if a token is not
+    enclosed in double-quotes, if is definitely not a list, number, or Boolean
+    type, then it is ultimately casted as a string.
+
+    :param v: The token to cast.
+    :param castbool: By default, castbool=True, casts token=True or token=False
+                     to Boolean type. Otherwise, castbool=False casts to string
+                     type.
+
+    :return: The casted token of type list, int, Boolean, or string.
+    """
     bool = {"True": True, "False": False}
-    if "," in v and not isstring(v):
-        v = [cast_kwargs(val, checkbool=checkbool) for val in v.split(",")]
-    elif v.isnumeric():
-        v = int(v)
-    elif checkbool and v in bool:
-        v = bool[v]
-    elif isstring(v):
-        v = v[1:-1]
+    if "," in token and not isstring(token):
+        token = [cast_kwargs(t, castbool=castbool) for t in token.split(",")]
+    elif token.isnumeric():
+        token = int(token)
+    elif castbool and token in bool:
+        token = bool[token]
+    elif isstring(token):
+        token = token[1:-1]
 
-    return v
+    return token
 
 
-def isstring(v):
-    return v[0] == '"' and v[-1] == '"'
+def isstring(token):
+    """
+    Determine if the token is a string.
+
+    :param token: The token.
+
+    :return: Boolean representing whether the token is a string.
+    """
+    return token[0] == '"' and token[-1] == '"'
 
 
 convert_from.add_command(csv)

--- a/commands/convert_from.py
+++ b/commands/convert_from.py
@@ -82,82 +82,14 @@ class FilterList(click.ParamType):
         return tiledb.FilterList(filter_list)
 
 
-class OptionalInt(click.ParamType):
-    name = "optional_int"
-
-    def convert(self, value, param, ctx):
-        try:
-            return int(value)
-        except ValueError:
-            self.fail(f"{value!r} is not a valid integer", param, ctx)
-
-
-class TileSpecifier(click.ParamType):
-    name = "tile_specifier"
-
-    def convert(self, value, param, ctx):
-        values = str(value).split(":")
-        if len(values) == 1:
-            try:
-                return int(values[0])
-            except ValueError:
-                self.fail(f"{values[0]!r} is not a valid integer", param, ctx)
-        elif len(values) == 2:
-            try:
-                return (values[0], int(values[1]))
-            except ValueError:
-                self.fail(f"{values[0]!r} is not a valid integer", param, ctx)
-        else:
-            self.fail(f"Too many arguments provided", param, ctx)
-
-
-@click.command()
+@click.command(
+    name="csv",
+    context_settings=dict(ignore_unknown_options=True, allow_extra_args=True),
+)
 @click.argument("csv_file")
 @click.argument("uri")
 @click.option(
-    "--allows-duplicates/--no-duplicates",
-    help=(
-        "Generated schema should allow duplicates. "
-        "By default, duplicates are allowed"
-    ),
-    default=True,
-)
-@click.option(
-    "--cell-order",
-    "-c",
-    metavar="(row-major | col-major | global)",
-    help=("Specify the cell ordering. By default, row-major"),
-    type=click.Choice(["row-major", "col-major", "global"], case_sensitive=True),
-    default="row-major",
-)
-@click.option(
-    "--tile-order",
-    "-t",
-    metavar="(row-major | col-major | global)",
-    help=("Specify the tile ordering. By default, row-major"),
-    type=click.Choice(["row-major", "col-major", "global"], case_sensitive=True),
-    default="row-major",
-)
-@click.option(
-    "--mode",
-    "-m",
-    metavar="(ingest | schema_only | append)",
-    help=("Specify the ingestion mode. By default, ingest"),
-    type=click.Choice(["ingest", "schema_only", "append"], case_sensitive=True),
-    default="ingest",
-)
-@click.option(
-    "--full-domain/--limited-domain",
-    help=(
-        "Specify whether dimensions should be created with full range of the dtype. "
-        "By default, the limited-domain ranges from the min and max values of "
-        "the ingested CSV file"
-    ),
-    default=False,
-)
-@click.option(
     "--attr-filters",
-    "-A",
     metavar="<filter name>,<filter name>,... | <attr name>:<filter name>,<filter name>,...",
     help=(
         "Provide a comma separated list of filters to apply to each attribute. "
@@ -170,8 +102,13 @@ class TileSpecifier(click.ParamType):
     default=(),
 )
 @click.option(
+    "--coords-filters",
+    metavar="<filter name>,<filter name>,...",
+    help=("Provide a comma separated list of filters to apply to each coordinate. "),
+    type=FilterList(),
+)
+@click.option(
     "--dim-filters",
-    "-D",
     metavar="<filter name>,<filter name>,... | <attr name>:<filter name>,<filter name>,...",
     help=(
         "Provide a comma separated list of filters to apply to each dimension. "
@@ -182,62 +119,6 @@ class TileSpecifier(click.ParamType):
     multiple=True,
     type=FilterList(),
     default=(),
-)
-@click.option(
-    "--coords-filters",
-    "-C",
-    metavar="<filter name>,<filter name>,...",
-    help=("Provide a comma separated list of filters to apply to each coordinate. "),
-    type=FilterList(),
-)
-@click.option(
-    "--sparse/--dense",
-    help=(
-        "Specify whether the resulting array should be sparse or dense. "
-        "By default, sparse"
-    ),
-    default=True,
-)
-@click.option(
-    "--tile",
-    "-T",
-    metavar="<int> | <column name>:<int>",
-    help=(
-        "Providing a single <int> will apply the tiling to each dimension. "
-        "Assign tiling to a specific dimension by providing the <column name>:<int>. "
-        "Alternatively, assign tilling to each dimension by passing the flag "
-        "multiple times (e.g. '-T dim_x:5 -T dim_y:8')"
-    ),
-    multiple=True,
-    type=TileSpecifier(),
-    default=(),
-)
-@click.option(
-    "--capacity",
-    "-n",
-    metavar="<int>",
-    help=("Schema capacity. By default, 0, which uses the libtiledb internal default"),
-    type=int,
-    default=0,
-)
-@click.option(
-    "--timestamp",
-    "-u",
-    metavar="<int>",
-    help=(
-        "Write TileDB array at specific UNIX timestamp. "
-        "By default, the current system time"
-    ),
-    type=OptionalInt(),
-    default=None,
-)
-@click.option(
-    "--row-start-idx",
-    "-r",
-    metavar="<int>",
-    help=("Start index to start new write (for row-indexed ingestions). By default, 0"),
-    type=int,
-    default=0,
 )
 @click.option(
     "--date-spec",
@@ -256,41 +137,15 @@ class TileSpecifier(click.ParamType):
     nargs=2,
     type=str,
 )
-def csv(
-    csv_file,
-    uri,
-    # tiledb keyword args
-    allows_duplicates,
-    cell_order,
-    tile_order,
-    mode,
-    full_domain,
-    attr_filters,
-    dim_filters,
-    coords_filters,
-    sparse,
-    tile,
-    capacity,
-    timestamp,
-    row_start_idx,
-    date_spec,
-    # pandas keyword args
-):
+@click.pass_context
+def csv(ctx, csv_file, uri, attr_filters, coords_filters, dim_filters, date_spec):
     """
     Convert a csv_file into a TileDB array located at uri.
-
-    Available <filter name> options: GzipFilter, ZstdFilter, LZ4Filter, Bzip2Filter, RleFilter, DoubleDeltaFilter, BitShuffleFilter, ByteShuffleFilter, BitWidthReductionFilter, PositiveDeltaFilter
     """
-    if tile:
-        if len(tile) == 1 and isinstance(tile[0], int):
-            tile = tile[0]
-        else:
-            if any(isinstance(t, int) for t in tile):
-                raise click.BadOptionUsage(
-                    "The --tile/-t flag can only be used once if using an <int> argument. "
-                    "Multiple uses of the flag require <column name>:<int> arguments."
-                )
-            tile = dict(tile)
+
+    kwargs = dict()
+
+    bool = {"True": True, "False": False}
 
     if attr_filters:
         if len(attr_filters) == 1:
@@ -303,6 +158,10 @@ def csv(
                     "<attr name>:<filter list> arguments."
                 )
             attr_filters = dict(attr_filters)
+        kwargs["attr_filters"] = attr_filters
+
+    if coords_filters:
+        kwargs["coords_filters"] = coords_filters
 
     if dim_filters:
         if len(dim_filters) == 1:
@@ -315,26 +174,46 @@ def csv(
                     "<attr name>:<filter list> arguments."
                 )
             dim_filters = dict(dim_filters)
+        kwargs["dim_filters"] = dim_filters
+
+    if date_spec:
+        kwargs["date_spec"] = dict(date_spec)
+
+    for arg in ctx.args:
+        dashedoption, sep, rhs = arg.partition("=")
+
+        if dashedoption[:2] == "--":
+            opt = dashedoption[2:]
+        else:
+            raise click.UsageError(f"Saw ill-formed option {arg}.")
+
+        opt = opt.replace("-", "_")
+        rhsvalues = rhs.split(",")
+        kwargsval = dict()
+        for rhsval in rhsvalues:
+            dictkey, sep, dictval = rhsval.partition(":")
+
+            # TODO clean this
+            if not dictval:
+                if dictkey.isnumeric():
+                    kwargs[opt] = int(dictkey)
+                elif dictkey in bool:
+                    kwargs[opt] = bool[dictkey]
+                else:
+                    kwargs[opt] = str(dictkey)
+            else:
+                if dictval.isnumeric():
+                    kwargsval[dictkey] = int(dictval)
+                elif dictval in bool:
+                    kwargsval[dictkey] = bool[dictval]
+                else:
+                    kwargsval[dictkey] = str(dictval)
+                kwargs[opt] = kwargsval
 
     tiledb.from_csv(
         uri,
         csv_file,
-        # tiledb keyword args
-        allows_duplicates=allows_duplicates,
-        cell_order=cell_order,
-        tile_order=tile_order,
-        mode=mode,
-        full_domain=full_domain,
-        attr_filters=attr_filters if attr_filters else None,
-        dim_filters=dim_filters if dim_filters else None,
-        coords_filters=coords_filters if coords_filters else None,
-        sparse=sparse,
-        tile=tile if tile else None,
-        capacity=capacity,
-        timestamp=timestamp,
-        row_start_idx=row_start_idx,
-        date_spec=dict(date_spec) if date_spec else None,
-        # pandas keyword args
+        **kwargs,
     )
 
 

--- a/tests/test_convert_from.py
+++ b/tests/test_convert_from.py
@@ -63,13 +63,13 @@ class TestCSV:
             "--boolisstr",
             '"False"',
             "--dictints",
-            "hello:1,world:2",
+            "hello:1;world:2",
             "--dictstrs",
-            'hello:world,"1":"2"',
+            'hello:world;"1":"2"',
             "--dictbools",
-            "good:True,bye:False",
+            "good:True;bye:False",
             "--dictmix",
-            'bool:False,str:"1",int:2,3:"three"',
+            'bool:False;str:"1";int:2;3:"three";list:hey,"hi",True,1',
             "--listabc",
             "a,b,c",
             "--list123",
@@ -90,7 +90,13 @@ class TestCSV:
         assert kwargs["dictints"] == {"hello": 1, "world": 2}
         assert kwargs["dictstrs"] == {"hello": "world", "1": "2"}
         assert kwargs["dictbools"] == {"good": True, "bye": False}
-        assert kwargs["dictmix"] == {"bool": False, "str": "1", "int": 2, 3: "three"}
+        assert kwargs["dictmix"] == {
+            "bool": False,
+            "str": "1",
+            "int": 2,
+            3: "three",
+            "list": ["hey", "hi", True, 1],
+        }
         assert kwargs["listabc"] == ["a", "b", "c"]
         assert kwargs["list123"] == [1, 2, 3]
         assert kwargs["listbool"] == [True, True, False]

--- a/tests/test_convert_from.py
+++ b/tests/test_convert_from.py
@@ -673,6 +673,7 @@ class TestCSV:
             assert array.df[:].columns[2] == "b"
             assert array.df[:].columns[3] == "a"
 
+    @pytest.mark.skip("does not work on windows?")
     def test_skiprows(self, temp_rootdir, create_test_simple_csv):
         """
         Test for command

--- a/tests/test_convert_from.py
+++ b/tests/test_convert_from.py
@@ -48,39 +48,36 @@ def create_test_simple_csv(temp_rootdir):
 
 class TestCSV:
     def test_parse_kwargs(self):
-        class ctx:
-            args = None
-
-        ctx.args = [
-            "--bool",
-            "True",
-            "--str",
-            "helloworld",
-            "--num",
-            "2",
-            "--numisstr",
-            '"2"',
-            "--boolisstr",
-            '"False"',
-            "--dictints",
-            "hello:1;world:2",
-            "--dictstrs",
-            'hello:world;"1":"2"',
-            "--dictbools",
-            "good:True;bye:False",
-            "--dictmix",
-            'bool:False;str:"1";int:2;3:"three";list:hey,"hi",True,1',
-            "--listabc",
-            "a,b,c",
-            "--list123",
-            "1,2,3",
-            "--listbool",
-            "True,True,False",
-            "--listmix",
-            'False,"1",2',
-        ]
-
-        kwargs = parse_kwargs(ctx)
+        kwargs = parse_kwargs(
+            [
+                "--bool",
+                "True",
+                "--str",
+                "helloworld",
+                "--num",
+                "2",
+                "--numisstr",
+                '"2"',
+                "--boolisstr",
+                '"False"',
+                "--dictints",
+                "hello:1;world:2",
+                "--dictstrs",
+                'hello:world;"1":"2"',
+                "--dictbools",
+                "good:True;bye:False",
+                "--dictmix",
+                'bool:False;str:"1";int:2;3:"three";list:hey,"hi",True,1',
+                "--listabc",
+                "a,b,c",
+                "--list123",
+                "1,2,3",
+                "--listbool",
+                "True,True,False",
+                "--listmix",
+                'False,"1",2',
+            ]
+        )
 
         assert kwargs["bool"] == True
         assert kwargs["str"] == "helloworld"

--- a/tests/test_convert_from.py
+++ b/tests/test_convert_from.py
@@ -76,7 +76,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] --sparse=True
+            tiledb convert_from [csv_file] [uri] --sparse True
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -85,7 +85,7 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "--sparse=True"],
+            ["convert-from", "csv", input_path, uri, "--sparse", "True"],
         )
 
         assert result.exit_code == 0
@@ -97,7 +97,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] --sparse=False
+            tiledb convert_from [csv_file] [uri] --sparse False
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -106,7 +106,7 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "--sparse=False"],
+            ["convert-from", "csv", input_path, uri, "--sparse", "False"],
         )
 
         assert result.exit_code == 0
@@ -118,7 +118,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] --allows-duplicates=(False|True)
+            tiledb convert_from [csv_file] [uri] --allows-duplicates (False|True)
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -133,8 +133,10 @@ class TestCSV:
                 "csv",
                 input_path,
                 uri,
-                "--sparse=True",
-                "--allows-duplicates=False",
+                "--sparse",
+                "True",
+                "--allows-duplicates",
+                "False",
             ],
         )
 
@@ -153,8 +155,10 @@ class TestCSV:
                 "csv",
                 input_path,
                 uri,
-                "--sparse=True",
-                "--allows-duplicates=True",
+                "--sparse",
+                "True",
+                "--allows-duplicates",
+                "True",
             ],
         )
 
@@ -167,7 +171,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] --capacity=<int>
+            tiledb convert_from [csv_file] [uri] --capacity <int>
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -176,7 +180,7 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "--capacity=123456"],
+            ["convert-from", "csv", input_path, uri, "--capacity", "123456"],
         )
 
         assert result.exit_code == 0
@@ -188,7 +192,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] --cell-order=(row-major|col-major|global)
+            tiledb convert_from [csv_file] [uri] --cell-order (row-major|col-major|global)
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -197,7 +201,7 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "--cell-order=global"],
+            ["convert-from", "csv", input_path, uri, "--cell-order", "global"],
         )
 
         assert result.exit_code == 0
@@ -209,7 +213,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] --full-domain
+            tiledb convert_from [csv_file] [uri] --full-domain (True|False)
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -218,7 +222,7 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "--full-domain=True"],
+            ["convert-from", "csv", input_path, uri, "--full-domain", "True"],
         )
 
         assert result.exit_code == 0
@@ -232,7 +236,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] --date-spec <column> <datetime format spec>
+            tiledb convert_from [csv_file] [uri] --date-spec <column>:<datetime format spec>,...
         """
         test_name, expected_output = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -241,7 +245,7 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "-d", "date", "%b/%d/%Y"],
+            ["convert-from", "csv", input_path, uri, "--date-spec", "date:%b/%d/%Y"],
         )
 
         assert result.exit_code == 0
@@ -256,7 +260,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] --mode=(ingest|schema_only|append)
+            tiledb convert_from [csv_file] [uri] --mode (ingest|schema_only|append)
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -270,8 +274,10 @@ class TestCSV:
                 "csv",
                 input_path,
                 uri,
-                "--sparse=True",
-                "--mode=schema_only",
+                "--sparse",
+                "True",
+                "--mode",
+                "schema_only",
             ],
         )
 
@@ -284,7 +290,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] --row-start-idx=<int>
+            tiledb convert_from [csv_file] [uri] --row-start-idx <int>
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -298,8 +304,10 @@ class TestCSV:
                 "csv",
                 input_path,
                 uri,
-                "--sparse=False",
-                "--row-start-idx=5",
+                "--sparse",
+                "False",
+                "--row-start-idx",
+                "5",
             ],
         )
 
@@ -313,7 +321,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] --cell-order=(row-major|col-major|global)
+            tiledb convert_from [csv_file] [uri] --cell-order (row-major|col-major|global)
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -322,7 +330,7 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "--cell-order=col-major"],
+            ["convert-from", "csv", input_path, uri, "--cell-order", "col-major"],
         )
 
         assert result.exit_code == 0
@@ -334,7 +342,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] --tile=<int>
+            tiledb convert_from [csv_file] [uri] --tile <int>
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -343,7 +351,7 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "--tile=2"],
+            ["convert-from", "csv", input_path, uri, "--tile", "2"],
         )
 
         assert result.exit_code == 0
@@ -355,7 +363,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] --tile=<attr>:<int>
+            tiledb convert_from [csv_file] [uri] --tile <attr>:<int>,...
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -364,7 +372,7 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "--tile=__tiledb_rows:2"],
+            ["convert-from", "csv", input_path, uri, "--tile", "__tiledb_rows:2"],
         )
 
         assert result.exit_code == 0
@@ -376,7 +384,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] --timestamp=<int>
+            tiledb convert_from [csv_file] [uri] --timestamp <int>
         """
         test_name, expected_output = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -391,9 +399,12 @@ class TestCSV:
                 "csv",
                 input_path,
                 uri,
-                "--sparse=True",
-                "--mode=ingest",
-                "--timestamp=1",
+                "--sparse",
+                "True",
+                "--mode",
+                "ingest",
+                "--timestamp",
+                "1",
             ],
         )
 
@@ -406,9 +417,12 @@ class TestCSV:
                 "csv",
                 input_path,
                 uri,
-                "--sparse=True",
-                "--mode=append",
-                "--timestamp=2",
+                "--sparse",
+                "True",
+                "--mode",
+                "append",
+                "--timestamp",
+                "2",
             ],
         )
 
@@ -547,78 +561,72 @@ class TestCSV:
             assert array.schema.domain.dim(0).filters.nfilters == 1
             assert array.schema.domain.dim(0).filters[0] == tiledb.GzipFilter(9)
 
-    # # @pytest.mark.skip(reason="TODO implement full test")
-    # def test_sep(self, temp_rootdir, create_test_simple_csv):
-    #     """
-    #     Test for command
+    # @pytest.mark.skip(reason="TODO implement full test")
+    def test_sep(self, temp_rootdir, create_test_simple_csv):
+        """
+        Test for command
 
-    #         tiledb convert_from [csv_file] [uri] -s <str>
-    #     """
-    #     test_name, _ = create_test_simple_csv
-    #     input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
-    #     uri = os.path.join(temp_rootdir, "test_sep.tdb")
+            tiledb convert_from [csv_file] [uri] --sep <str>
+        """
+        test_name, _ = create_test_simple_csv
+        input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
+        uri = os.path.join(temp_rootdir, "test_sep.tdb")
 
-    #     runner = CliRunner()
-    #     result = runner.invoke(
-    #         root, ["convert-from", "csv", input_path, uri, "--sep=a"]
-    #     )
+        runner = CliRunner()
+        result = runner.invoke(
+            root, ["convert-from", "csv", input_path, uri, "--sep", " "]
+        )
 
-    #     assert result.exit_code == 0
-    #     with tiledb.open(uri) as array:
-    #         print(array.df[:])
+        assert result.exit_code == 0
+        with tiledb.open(uri) as array:
+            print(array.df[:])
 
     # @pytest.mark.skip("TODO implement full test")
-    # def test_header(self, temp_rootdir, create_test_simple_csv):
-    #     """
-    #     Test for command
+    def test_header(self, temp_rootdir, create_test_simple_csv):
+        """
+        Test for command
 
-    #         tiledb convert_from [csv_file] [uri] -h <int>
-    #     """
-    #     test_name, _ = create_test_simple_csv
-    #     input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
-    #     uri = os.path.join(temp_rootdir, "test_header.tdb")
+            tiledb convert_from [csv_file] [uri] -h <int>
+        """
+        test_name, _ = create_test_simple_csv
+        input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
+        uri = os.path.join(temp_rootdir, "test_header.tdb")
 
-    #     runner = CliRunner()
-    #     result = runner.invoke(
-    #         root, ["convert-from", "csv", input_path, uri, "--header=2"]
-    #     )
+        runner = CliRunner()
+        result = runner.invoke(
+            root, ["convert-from", "csv", input_path, uri, "--header", "2"]
+        )
 
-    #     assert result.exit_code == 0
-    #     with tiledb.open(uri) as array:
-    #         print(array.df[:])
+        assert result.exit_code == 0
+        with tiledb.open(uri) as array:
+            print(array.df[:])
 
-    # # @pytest.mark.skip("TODO implement full test")
-    # def test_names(self, temp_rootdir, create_test_simple_csv):
-    #     """
-    #     Test for command
+    # @pytest.mark.skip("TODO implement full test")
+    def test_names(self, temp_rootdir, create_test_simple_csv):
+        """
+        Test for command
 
-    #         tiledb convert_from [csv_file] [uri] -N <column name>
-    #     """
-    #     test_name, _ = create_test_simple_csv
-    #     input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
-    #     uri = os.path.join(temp_rootdir, "test_names.tdb")
+            tiledb convert_from [csv_file] [uri] --names <column name>,...
+        """
+        test_name, _ = create_test_simple_csv
+        input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
+        uri = os.path.join(temp_rootdir, "test_names.tdb")
 
-    #     runner = CliRunner()
-    #     result = runner.invoke(
-    #         root,
-    #         [
-    #             "convert-from",
-    #             "csv",
-    #             input_path,
-    #             uri,
-    #             "-h",
-    #             0,
-    #             "-N",
-    #             "d",
-    #             "-N",
-    #             "c",
-    #             "-N",
-    #             "b",
-    #             "-N",
-    #             "a",
-    #         ],
-    #     )
+        runner = CliRunner()
+        result = runner.invoke(
+            root,
+            [
+                "convert-from",
+                "csv",
+                input_path,
+                uri,
+                "--header",
+                "0",
+                "--names",
+                "d,c,b,a",
+            ],
+        )
 
-    #     assert result.exit_code == 0
-    #     with tiledb.open(uri) as array:
-    #         print(array.df[:])
+        assert result.exit_code == 0
+        with tiledb.open(uri) as array:
+            print(array.df[:])

--- a/tests/test_convert_from.py
+++ b/tests/test_convert_from.py
@@ -76,7 +76,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] --sparse
+            tiledb convert_from [csv_file] [uri] --sparse=True
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -85,7 +85,7 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "--sparse"],
+            ["convert-from", "csv", input_path, uri, "--sparse=True"],
         )
 
         assert result.exit_code == 0
@@ -97,7 +97,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] --dense
+            tiledb convert_from [csv_file] [uri] --sparse=False
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -106,7 +106,7 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "--dense"],
+            ["convert-from", "csv", input_path, uri, "--sparse=False"],
         )
 
         assert result.exit_code == 0
@@ -118,7 +118,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] --no-duplicates
+            tiledb convert_from [csv_file] [uri] --allows-duplicates=(False|True)
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -128,7 +128,14 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "--sparse", "--no-duplicates"],
+            [
+                "convert-from",
+                "csv",
+                input_path,
+                uri,
+                "--sparse=True",
+                "--allows-duplicates=False",
+            ],
         )
 
         assert result.exit_code == 0
@@ -141,7 +148,14 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "--sparse", "--allows-duplicates"],
+            [
+                "convert-from",
+                "csv",
+                input_path,
+                uri,
+                "--sparse=True",
+                "--allows-duplicates=True",
+            ],
         )
 
         assert result.exit_code == 0
@@ -153,7 +167,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] -n <int>
+            tiledb convert_from [csv_file] [uri] --capacity=<int>
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -162,7 +176,7 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "-n", 123456],
+            ["convert-from", "csv", input_path, uri, "--capacity=123456"],
         )
 
         assert result.exit_code == 0
@@ -174,7 +188,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] -c (row-major | column-major | global)
+            tiledb convert_from [csv_file] [uri] --cell-order=(row-major|col-major|global)
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -183,7 +197,7 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "-c", "global"],
+            ["convert-from", "csv", input_path, uri, "--cell-order=global"],
         )
 
         assert result.exit_code == 0
@@ -204,7 +218,7 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "--full-domain"],
+            ["convert-from", "csv", input_path, uri, "--full-domain=True"],
         )
 
         assert result.exit_code == 0
@@ -242,7 +256,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] -m (ingest | schema_only | append)
+            tiledb convert_from [csv_file] [uri] --mode=(ingest|schema_only|append)
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -251,7 +265,14 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "-m", "schema_only"],
+            [
+                "convert-from",
+                "csv",
+                input_path,
+                uri,
+                "--sparse=True",
+                "--mode=schema_only",
+            ],
         )
 
         assert result.exit_code == 0
@@ -263,7 +284,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] -r <int>
+            tiledb convert_from [csv_file] [uri] --row-start-idx=<int>
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -272,7 +293,14 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "--dense", "-r", 5],
+            [
+                "convert-from",
+                "csv",
+                input_path,
+                uri,
+                "--sparse=False",
+                "--row-start-idx=5",
+            ],
         )
 
         assert result.exit_code == 0
@@ -285,7 +313,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] -c (row-major | col-major | global)
+            tiledb convert_from [csv_file] [uri] --cell-order=(row-major|col-major|global)
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -294,7 +322,7 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "-c", "col-major"],
+            ["convert-from", "csv", input_path, uri, "--cell-order=col-major"],
         )
 
         assert result.exit_code == 0
@@ -306,7 +334,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] -T <int>
+            tiledb convert_from [csv_file] [uri] --tile=<int>
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -315,7 +343,7 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "-T", 2],
+            ["convert-from", "csv", input_path, uri, "--tile=2"],
         )
 
         assert result.exit_code == 0
@@ -327,7 +355,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] -T <int>
+            tiledb convert_from [csv_file] [uri] --tile=<attr>:<int>
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -336,10 +364,8 @@ class TestCSV:
         runner = CliRunner()
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "-T", "__tiledb_rows:2"],
+            ["convert-from", "csv", input_path, uri, "--tile=__tiledb_rows:2"],
         )
-
-        print(result.stdout)
 
         assert result.exit_code == 0
 
@@ -350,7 +376,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] -u <int>
+            tiledb convert_from [csv_file] [uri] --timestamp=<int>
         """
         test_name, expected_output = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -360,14 +386,32 @@ class TestCSV:
 
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "-m", "ingest", "-u", 1],
+            [
+                "convert-from",
+                "csv",
+                input_path,
+                uri,
+                "--sparse=True",
+                "--mode=ingest",
+                "--timestamp=1",
+            ],
         )
+
         assert result.exit_code == 0
 
         result = runner.invoke(
             root,
-            ["convert-from", "csv", input_path, uri, "-m", "append", "-u", 2],
+            [
+                "convert-from",
+                "csv",
+                input_path,
+                uri,
+                "--sparse=True",
+                "--mode=append",
+                "--timestamp=2",
+            ],
         )
+
         assert result.exit_code == 0
 
         with tiledb.open(uri, timestamp=1) as array:
@@ -386,7 +430,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] -A <filter name>,<filter name>,...
+            tiledb convert_from [csv_file] [uri] --attr-filters <filter name>,<filter name>,...
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -394,7 +438,8 @@ class TestCSV:
 
         runner = CliRunner()
         result = runner.invoke(
-            root, ["convert-from", "csv", input_path, uri, "-A", "GzipFilter=9"]
+            root,
+            ["convert-from", "csv", input_path, uri, "--attr-filters", "GzipFilter=9"],
         )
 
         assert result.exit_code == 0
@@ -416,7 +461,7 @@ class TestCSV:
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] -A <attr name>:<filter name>,<filter name>,...
+            tiledb convert_from [csv_file] [uri] --attr-filters <attr name>:<filter name>,<filter name>,...
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -430,9 +475,9 @@ class TestCSV:
                 "csv",
                 input_path,
                 uri,
-                "-A",
+                "--attr-filters",
                 "a:LZ4Filter=10,BitShuffleFilter",
-                "-A",
+                "--attr-filters",
                 "b:DoubleDeltaFilter,PositiveDeltaFilter=3",
             ],
         )
@@ -452,31 +497,11 @@ class TestCSV:
 
             assert array.schema.attr("date").filters.nfilters == 0
 
-    def test_dim_filters(self, temp_rootdir, create_test_simple_csv):
-        """
-        Test for command
-
-            tiledb convert_from [csv_file] [uri] -D <filter name>,<filter name>,...
-        """
-        test_name, _ = create_test_simple_csv
-        input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
-        uri = os.path.join(temp_rootdir, "test_dim_filters.tdb")
-
-        runner = CliRunner()
-        result = runner.invoke(
-            root, ["convert-from", "csv", input_path, uri, "-D", "GzipFilter=9"]
-        )
-        assert result.exit_code == 0
-
-        with tiledb.open(uri) as array:
-            assert array.schema.domain.dim(0).filters.nfilters == 1
-            assert array.schema.domain.dim(0).filters[0] == tiledb.GzipFilter(9)
-
     def test_coords_filters(self, temp_rootdir, create_test_simple_csv):
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] -C <filter name>,<filter name>,...
+            tiledb convert_from [csv_file] [uri] --coords-filters <filter name>,<filter name>,...
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -484,7 +509,15 @@ class TestCSV:
 
         runner = CliRunner()
         result = runner.invoke(
-            root, ["convert-from", "csv", input_path, uri, "-C", "GzipFilter=9"]
+            root,
+            [
+                "convert-from",
+                "csv",
+                input_path,
+                uri,
+                "--coords-filters",
+                "GzipFilter=9",
+            ],
         )
 
         assert result.exit_code == 0
@@ -492,3 +525,100 @@ class TestCSV:
         with tiledb.open(uri) as array:
             assert array.schema.coords_filters.nfilters == 1
             assert array.schema.coords_filters[0] == tiledb.GzipFilter(9)
+
+    def test_dim_filters(self, temp_rootdir, create_test_simple_csv):
+        """
+        Test for command
+
+            tiledb convert_from [csv_file] [uri] --dim-filters <filter name>,<filter name>,...
+        """
+        test_name, _ = create_test_simple_csv
+        input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
+        uri = os.path.join(temp_rootdir, "test_dim_filters.tdb")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            root,
+            ["convert-from", "csv", input_path, uri, "--dim-filters", "GzipFilter=9"],
+        )
+        assert result.exit_code == 0
+
+        with tiledb.open(uri) as array:
+            assert array.schema.domain.dim(0).filters.nfilters == 1
+            assert array.schema.domain.dim(0).filters[0] == tiledb.GzipFilter(9)
+
+    # # @pytest.mark.skip(reason="TODO implement full test")
+    # def test_sep(self, temp_rootdir, create_test_simple_csv):
+    #     """
+    #     Test for command
+
+    #         tiledb convert_from [csv_file] [uri] -s <str>
+    #     """
+    #     test_name, _ = create_test_simple_csv
+    #     input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
+    #     uri = os.path.join(temp_rootdir, "test_sep.tdb")
+
+    #     runner = CliRunner()
+    #     result = runner.invoke(
+    #         root, ["convert-from", "csv", input_path, uri, "--sep=a"]
+    #     )
+
+    #     assert result.exit_code == 0
+    #     with tiledb.open(uri) as array:
+    #         print(array.df[:])
+
+    # @pytest.mark.skip("TODO implement full test")
+    # def test_header(self, temp_rootdir, create_test_simple_csv):
+    #     """
+    #     Test for command
+
+    #         tiledb convert_from [csv_file] [uri] -h <int>
+    #     """
+    #     test_name, _ = create_test_simple_csv
+    #     input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
+    #     uri = os.path.join(temp_rootdir, "test_header.tdb")
+
+    #     runner = CliRunner()
+    #     result = runner.invoke(
+    #         root, ["convert-from", "csv", input_path, uri, "--header=2"]
+    #     )
+
+    #     assert result.exit_code == 0
+    #     with tiledb.open(uri) as array:
+    #         print(array.df[:])
+
+    # # @pytest.mark.skip("TODO implement full test")
+    # def test_names(self, temp_rootdir, create_test_simple_csv):
+    #     """
+    #     Test for command
+
+    #         tiledb convert_from [csv_file] [uri] -N <column name>
+    #     """
+    #     test_name, _ = create_test_simple_csv
+    #     input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
+    #     uri = os.path.join(temp_rootdir, "test_names.tdb")
+
+    #     runner = CliRunner()
+    #     result = runner.invoke(
+    #         root,
+    #         [
+    #             "convert-from",
+    #             "csv",
+    #             input_path,
+    #             uri,
+    #             "-h",
+    #             0,
+    #             "-N",
+    #             "d",
+    #             "-N",
+    #             "c",
+    #             "-N",
+    #             "b",
+    #             "-N",
+    #             "a",
+    #         ],
+    #     )
+
+    #     assert result.exit_code == 0
+    #     with tiledb.open(uri) as array:
+    #         print(array.df[:])

--- a/tests/test_convert_from.py
+++ b/tests/test_convert_from.py
@@ -456,6 +456,7 @@ class TestCSV:
             ["convert-from", "csv", input_path, uri, "--attr-filters", "GzipFilter=9"],
         )
 
+        print(result.stdout)
         assert result.exit_code == 0
 
         with tiledb.open(uri) as array:
@@ -490,12 +491,14 @@ class TestCSV:
                 input_path,
                 uri,
                 "--attr-filters",
-                "a:LZ4Filter=10,BitShuffleFilter",
-                "--attr-filters",
-                "b:DoubleDeltaFilter,PositiveDeltaFilter=3",
+                (
+                    "a:LZ4Filter=10,BitShuffleFilter;"
+                    "b:DoubleDeltaFilter,PositiveDeltaFilter=3"
+                ),
             ],
         )
 
+        print(result.stdout)
         assert result.exit_code == 0
 
         with tiledb.open(uri) as array:
@@ -534,6 +537,7 @@ class TestCSV:
             ],
         )
 
+        print(result.stdout)
         assert result.exit_code == 0
 
         with tiledb.open(uri) as array:
@@ -555,6 +559,7 @@ class TestCSV:
             root,
             ["convert-from", "csv", input_path, uri, "--dim-filters", "GzipFilter=9"],
         )
+        print(result.stdout)
         assert result.exit_code == 0
 
         with tiledb.open(uri) as array:
@@ -618,7 +623,7 @@ class TestCSV:
 
             tiledb convert_from [csv_file] [uri] --skiprows <int>,...
         """
-        test_name, expected_output = create_test_simple_csv
+        test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
         uri = os.path.join(temp_rootdir, "test_skiprows.tdb")
 

--- a/tests/test_convert_from.py
+++ b/tests/test_convert_from.py
@@ -1,5 +1,6 @@
 import tiledb
 from commands.root import root
+from commands.convert_from import parse_kwargs
 
 from click.testing import CliRunner
 import os
@@ -46,7 +47,56 @@ def create_test_simple_csv(temp_rootdir):
 
 
 class TestCSV:
-    def test(self, temp_rootdir, create_test_simple_csv):
+    def test_parse_kwargs(self):
+        class ctx:
+            args = None
+
+        ctx.args = [
+            "--bool",
+            "True",
+            "--str",
+            "helloworld",
+            "--num",
+            "2",
+            "--numisstr",
+            '"2"',
+            "--boolisstr",
+            '"False"',
+            "--dictints",
+            "hello:1,world:2",
+            "--dictstrs",
+            'hello:world,"1":"2"',
+            "--dictbools",
+            "good:True,bye:False",
+            "--dictmix",
+            'bool:False,str:"1",int:2,3:"three"',
+            "--listabc",
+            "a,b,c",
+            "--list123",
+            "1,2,3",
+            "--listbool",
+            "True,True,False",
+            "--listmix",
+            'False,"1",2',
+        ]
+
+        kwargs = parse_kwargs(ctx)
+
+        assert kwargs["bool"] == True
+        assert kwargs["str"] == "helloworld"
+        assert kwargs["num"] == 2
+        assert kwargs["numisstr"] == "2"
+        assert kwargs["boolisstr"] == "False"
+        assert kwargs["dictints"] == {"hello": 1, "world": 2}
+        assert kwargs["dictstrs"] == {"hello": "world", "1": "2"}
+        assert kwargs["dictbools"] == {"good": True, "bye": False}
+        assert kwargs["dictmix"] == {"bool": False, "str": "1", "int": 2, 3: "three"}
+        assert kwargs["listabc"] == ["a", "b", "c"]
+        assert kwargs["list123"] == [1, 2, 3]
+        assert kwargs["listbool"] == [True, True, False]
+        assert kwargs["listmix"] == [False, "1", 2]
+
+    def test_no_options(self, temp_rootdir, create_test_simple_csv):
         """
         Test for command
 

--- a/tests/test_convert_from.py
+++ b/tests/test_convert_from.py
@@ -561,7 +561,6 @@ class TestCSV:
             assert array.schema.domain.dim(0).filters.nfilters == 1
             assert array.schema.domain.dim(0).filters[0] == tiledb.GzipFilter(9)
 
-    # @pytest.mark.skip(reason="TODO implement full test")
     def test_sep(self, temp_rootdir, create_test_simple_csv):
         """
         Test for command
@@ -579,34 +578,13 @@ class TestCSV:
 
         assert result.exit_code == 0
         with tiledb.open(uri) as array:
-            print(array.df[:])
+            assert len(array.df[:].columns) == 1
 
-    # @pytest.mark.skip("TODO implement full test")
-    def test_header(self, temp_rootdir, create_test_simple_csv):
+    def test_header_and_names(self, temp_rootdir, create_test_simple_csv):
         """
         Test for command
 
-            tiledb convert_from [csv_file] [uri] -h <int>
-        """
-        test_name, _ = create_test_simple_csv
-        input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
-        uri = os.path.join(temp_rootdir, "test_header.tdb")
-
-        runner = CliRunner()
-        result = runner.invoke(
-            root, ["convert-from", "csv", input_path, uri, "--header", "2"]
-        )
-
-        assert result.exit_code == 0
-        with tiledb.open(uri) as array:
-            print(array.df[:])
-
-    # @pytest.mark.skip("TODO implement full test")
-    def test_names(self, temp_rootdir, create_test_simple_csv):
-        """
-        Test for command
-
-            tiledb convert_from [csv_file] [uri] --names <column name>,...
+            tiledb convert_from [csv_file] [uri] --header 0 --names <column name>,...
         """
         test_name, _ = create_test_simple_csv
         input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
@@ -629,4 +607,27 @@ class TestCSV:
 
         assert result.exit_code == 0
         with tiledb.open(uri) as array:
-            print(array.df[:])
+            assert array.df[:].columns[0] == "d"
+            assert array.df[:].columns[1] == "c"
+            assert array.df[:].columns[2] == "b"
+            assert array.df[:].columns[3] == "a"
+
+    def test_skiprows(self, temp_rootdir, create_test_simple_csv):
+        """
+        Test for command
+
+            tiledb convert_from [csv_file] [uri] --skiprows <int>,...
+        """
+        test_name, expected_output = create_test_simple_csv
+        input_path = os.path.join(temp_rootdir, f"{test_name}.csv")
+        uri = os.path.join(temp_rootdir, "test_skiprows.tdb")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            root,
+            ["convert-from", "csv", input_path, uri, "--skiprows", "0,1"],
+        )
+
+        assert result.exit_code == 0
+        with tiledb.open(uri) as array:
+            assert len(array.df[:]) == 3


### PR DESCRIPTION
* Rather than implement each option, refactor csv() to use the newly implemented parse_kwargs() function